### PR TITLE
Fix issue with incorrectly loaded ames_new dataset

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -41,6 +41,6 @@ Suggests:
     xml2,
     modeldata
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.0
+RoxygenNote: 7.1.1
 VignetteBuilder: knitr
 Language: en-US

--- a/vignettes/continuous-data.Rmd
+++ b/vignettes/continuous-data.Rmd
@@ -136,8 +136,7 @@ ames_pca
 
 Plotting the distribution function for the PCA scores is also helpful:
 
-```{r autoplot, fig.align='center'}
-
+```{r autoplot, fig.align='center', fig.width=6}
 library(ggplot2)
 autoplot(ames_pca)
 ```

--- a/vignettes/continuous-data.Rmd
+++ b/vignettes/continuous-data.Rmd
@@ -69,6 +69,9 @@ the statistics estimated from the training set.
 library(recipes)
 library(dplyr)
 
+# Load custom houses from applicable.
+data(ames_new, package = "applicable")
+
 ames_cols <- names(ames_new)
 
 training_data <- 


### PR DESCRIPTION
The dataset `ames_new` is present in both the `applicable` and the `AmesHousing` packages. However, the version on `applicable` is cleaner and the **continuous-data** vignette assumes the data in this format. Not sure though why it was working before.

The fix was to explicitly load the `ames_new` from `applicable`.