### PR TITLE
add explicit line breaks to default print methods

### DIFF
--- a/R/print.R
+++ b/R/print.R
@@ -30,7 +30,7 @@ print.apd_pca <- function(x, ...) {
       total variation in the predictors."
   )
 
- cat(print_output)
+ cat(print_output, "\n")
 
  invisible(x)
 }
@@ -56,7 +56,7 @@ print.apd_hat_values <- function(x, ...) {
     "# Predictors:
         {predictors_count}"
   )
-  cat(print_output)
+  cat(print_output, "\n")
 
   invisible(x)
 }


### PR DESCRIPTION
Coz use of `cat` doesn't insert the line break like `glue`'s default `print` does. RStudio has its own internal mechanisms to avoid this, so you can't see the problem within RStudio, nor can I give you a `reprex`, because that also implements auto-insertion of implicitly missing line breaks. But if you try something like the following elsewhere, you'll see that no line break gets inserted:
``` r
predictors <- mtcars[, -1]
mod <- apt_pca(predictors)
print(mod)
```
This PR fixes, and does not change any of the auto-reformatted behaviour within RStudio or elsewhere.