### PR TITLE
Compatibility ggplot2 3.6.0

### DIFF
--- a/tests/testthat/test-plot.R
+++ b/tests/testthat/test-plot.R
@@ -1,3 +1,8 @@
+get_labs <- function(x) x$labels
+if ("get_labs" %in% getNamespaceExports("ggplot2")) {
+  get_labs <- ggplot2::get_labs
+}
+
 test_that("output of autoplot.apd_pca is correct when no options are provided", {
   ad <- apd_pca(mtcars)
   ad_plot <- ggplot2::autoplot(ad)
@@ -6,8 +11,9 @@ test_that("output of autoplot.apd_pca is correct when no options are provided", 
     tidyr::gather(component, value, -percentile)
 
   expect_equal(ad_plot$data, pctls)
-  expect_equal(ad_plot$labels$x, "abs(value)")
-  expect_equal(ad_plot$labels$y, "percentile")
+  labs <- get_labs(ad_plot)
+  expect_equal(labs$x, "abs(value)")
+  expect_equal(labs$y, "percentile")
 })
 
 test_that("output of autoplot.apd_pca is correct when options=matches are provided", {
@@ -19,8 +25,9 @@ test_that("output of autoplot.apd_pca is correct when options=matches are provid
     tidyr::gather(component, value, -percentile)
 
   expect_equal(ad_plot$data, pctls)
-  expect_equal(ad_plot$labels$x, "abs(value)")
-  expect_equal(ad_plot$labels$y, "percentile")
+  labs <- get_labs(ad_plot)
+  expect_equal(labs$x, "abs(value)")
+  expect_equal(labs$y, "percentile")
 })
 
 test_that("output of autoplot.apd_pca is correct when options=distance are provided", {
@@ -32,6 +39,7 @@ test_that("output of autoplot.apd_pca is correct when options=distance are provi
     tidyr::gather(component, value, -percentile)
 
   expect_equal(ad_plot$data, pctls)
-  expect_equal(ad_plot$labels$x, "abs(value)")
-  expect_equal(ad_plot$labels$y, "percentile")
+  labs <- get_labs(ad_plot)
+  expect_equal(labs$x, "abs(value)")
+  expect_equal(labs$y, "percentile")
 })


### PR DESCRIPTION
Hi tidymodels team,

Apologies for not posting an issue first.
The ggplot2 package is planning an update for around May 2025 and a reverse dependency test identified a problem with the applicable package.
The details are explained in https://github.com/tidyverse/ggplot2/issues/6290, but essentially ggplot2 doesn't populate the `plot$labels` field before plot building anymore, which violates some test assumptions in this package.

This PR changes the tests to be compatible with both versions of ggplot2. 
You can test the changes yourself with the development version of ggplot2 (`pak::pak("tidyverse/ggplot2")`)

Best,
Teun
